### PR TITLE
fix(Dockerfile): update Python version to 3.12 and ensure curl is installed

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,5 @@
-# Use Python 3.11 slim image
-FROM python:3.11-slim
+# Use Python 3.12 slim image
+FROM python:3.12-slim
 
 # Set working directory
 WORKDIR /app
@@ -14,6 +14,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         build-essential \
         libpq-dev \
+        curl \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy requirements and install Python dependencies


### PR DESCRIPTION
Upgrade the Python version in the Dockerfile to 3.12 and ensure that curl is installed as part of the setup process.